### PR TITLE
Fix double build for style types

### DIFF
--- a/config/externals.d.ts
+++ b/config/externals.d.ts
@@ -1,4 +1,0 @@
-declare module '*.less' {
-    const style: any;
-    export default style;
-}

--- a/config/typings.d.ts
+++ b/config/typings.d.ts
@@ -1,7 +1,0 @@
-declare module '*.css' {
-    interface IClassNames {
-      [className: string]: string
-    }
-    const classNames: IClassNames;
-    export = classNames;
-  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9628,6 +9628,49 @@
         "typed-css-modules": "^0.3.6"
       }
     },
+    "typed-css-modules-webpack-plugin": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/typed-css-modules-webpack-plugin/-/typed-css-modules-webpack-plugin-0.1.0.tgz",
+      "integrity": "sha512-sHitV+4xSftrtX0rLuPjKpQiGoNc1zIQKoUIBS3HGoHxO04MYBCPg/IcCpTHTPXwGha1oNso3f0QXtzHOSrH+Q==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "css-modules-loader-core": "^1.1.0",
+        "glob": "^7.1.3",
+        "typed-css-modules": "^0.3.7"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Empty new Typescript/Preact project",
   "main": "src/index.js",
   "scripts": {
-    "build": "node_modules/webpack/bin/webpack.js",
+    "build": "node_modules/webpack/bin/webpack.js --progress --color",
     "dev": "node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "lint": "node_modules/eslint/bin/eslint.js src/**/*.tsx src/**/*.scss src/**/*.less ; node_modules/stylelint/bin/stylelint.js src/**/*.scss src/**/*.less",
     "lintf": "node_modules/eslint/bin/eslint.js src/**/*.tsx src/**/*.scss src/**/*.less --fix ; node_modules/stylelint/bin/stylelint.js src/**/*.scss src/**/*.less --fix",
@@ -35,6 +35,7 @@
     "stylelint-config-recommended": "^2.1.0",
     "ts-loader": "^5.3.3",
     "typed-css-modules-loader": "0.0.17",
+    "typed-css-modules-webpack-plugin": "^0.1.0",
     "typescript": "^3.4.2",
     "typings-for-css-modules-loader": "^1.7.0",
     "webpack": "^4.29.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const CompressionPlugin = require('compression-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const {TypedCssModulesPlugin} = require('typed-css-modules-webpack-plugin');
 
 module.exports = {
   entry: "./src/pages/home.tsx",
@@ -88,6 +89,9 @@ module.exports = {
     }),
     new CompressionPlugin({
       algorithm: 'gzip'
+    }),
+    new TypedCssModulesPlugin({
+      globPattern: '{src/**/*.scss,src/**/*.less,src/**/*.css}',
     }),
   ],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,13 +25,16 @@ module.exports = {
   },
   module: {
     rules: [
-     {
+      {
+        test: /\.tsx?$/,
+        loader: "ts-loader",
+      },
+      {
         test: /\.less$/,
-        enforce: "pre",
         use: [
           { loader: "style-loader" },
           {
-            loader: "typings-for-css-modules-loader",
+            loader: "css-loader",
             options: {
               modules: true,
               namedExport: true
@@ -42,11 +45,10 @@ module.exports = {
       },
       {
         test: /\.scss$/,
-        enforce: "pre",
         use: [
           { loader: "style-loader" },
           {
-            loader: "typings-for-css-modules-loader",
+            loader: "css-loader",
             options: {
               modules: true,
               namedExport: true
@@ -55,11 +57,20 @@ module.exports = {
           { loader: "sass-loader" },
         ],
       },
-      { test: /\.css$/, loader: "style-loader!css-loader" },
-      // Handle .ts and .tsx file via ts-loader.
-      { test: /\.tsx?$/, loader: "ts-loader" },
+      {
+        test: /\.css$/,
+        use: [
+          { loader: "style-loader" },
+          {
+            loader: "css-loader",
+            options: {
+              modules: true,
+              namedExport: true
+            }
+          },
+        ],
+      },
       { test: /\.html$/, loader: 'html-loader' },
-      
     ],
   },
   optimization: {


### PR DESCRIPTION
## Summary
Switching to dropbox's [`typed-css-modules-webpack-plugin`](https://github.com/dropbox/typed-css-modules-webpack-plugin) to generate types for our stylesheets.

## Motivation
The old way failed on the first build.